### PR TITLE
Improvements to web application naming.

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -22,13 +22,15 @@ use Illuminate\Support\Arr;
 
 $metaClosure = function (Document $document) {
     $forumApiDocument = $document->getForumApiDocument();
-    $forumName = Arr::get($forumApiDocument, 'data.attributes.title');
     $basePath = rtrim(Arr::get($forumApiDocument, 'data.attributes.basePath'), '/');
+
+    $settings = app(SettingsRepositoryInterface::class);
+    $appName = $settings->get('askvortsov-pwa.shortName', $settings->get('askvortsov-pwa.longName', $settings->get('forum_title')));
 
     $document->head[] = "<link rel='manifest' href='$basePath/webmanifest'>";
     $document->head[] = "<meta name='apple-mobile-web-app-capable' content='yes'>";
     $document->head[] = "<meta id='apple-style' name='apple-mobile-web-app-status-bar-style' content='default'>";
-    $document->head[] = "<meta id='apple-title' name='apple-mobile-web-app-title' content='$forumName'>";
+    $document->head[] = "<meta id='apple-title' name='apple-mobile-web-app-title' content='$appName'>";
 
     $settings = resolve(SettingsRepositoryInterface::class);
 

--- a/js/src/admin/components/PWAPage.js
+++ b/js/src/admin/components/PWAPage.js
@@ -81,33 +81,13 @@ export default class PWAPage extends ExtensionPage {
 
             <fieldset class="parent">
               <fieldset>
-                <legend>
-                  {app.translator.trans(
-                    "askvortsov-pwa.admin.pwa.about.heading"
-                  )}
-                </legend>
-                <div className="helpText">
-                  {app.translator.trans(
-                    "askvortsov-pwa.admin.pwa.about.short_name_text"
-                  )}
-                </div>
-                <input
-                  className="FormControl"
-                  bidi={this.setting("askvortsov-pwa.shortName")}
-                  placeholder={this.setting("forum_title")()}
-                ></input>
+                <legend>{app.translator.trans('askvortsov-pwa.admin.pwa.about.heading')}</legend>
+                <div className="helpText">{app.translator.trans('askvortsov-pwa.admin.pwa.about.short_name_text')}</div>
+                <input className="FormControl" bidi={this.setting('askvortsov-pwa.shortName')} placeholder={this.setting('forum_title')()}></input>
               </fieldset>
               <fieldset>
-                <div className="helpText">
-                  {app.translator.trans(
-                    "askvortsov-pwa.admin.pwa.about.long_name_text"
-                  )}
-                </div>
-                <input
-                  className="FormControl"
-                  bidi={this.setting("askvortsov-pwa.longName")}
-                  placeholder={this.setting("forum_title")()}
-                />
+                <div className="helpText">{app.translator.trans('askvortsov-pwa.admin.pwa.about.long_name_text')}</div>
+                <input className="FormControl" bidi={this.setting('askvortsov-pwa.longName')} placeholder={this.setting('forum_title')()} />
               </fieldset>
               <fieldset>
                 <div className="helpText">{app.translator.trans('askvortsov-pwa.admin.pwa.about.description_text')}</div>

--- a/js/src/admin/components/PWAPage.js
+++ b/js/src/admin/components/PWAPage.js
@@ -81,13 +81,31 @@ export default class PWAPage extends ExtensionPage {
 
             <fieldset class="parent">
               <fieldset>
-                <legend>{app.translator.trans('askvortsov-pwa.admin.pwa.about.heading')}</legend>
-                <div className="helpText">{app.translator.trans('askvortsov-pwa.admin.pwa.about.short_name_text')}</div>
-                <input className="FormControl" value={this.manifest.short_name} disabled={true}></input>
+                <legend>
+                  {app.translator.trans(
+                    "askvortsov-pwa.admin.pwa.about.heading"
+                  )}
+                </legend>
+                <div className="helpText">
+                  {app.translator.trans(
+                    "askvortsov-pwa.admin.pwa.about.short_name_text"
+                  )}
+                </div>
+                <input
+                  className="FormControl"
+                  bidi={this.values["askvortsov-pwa.shortName"]}
+                ></input>
               </fieldset>
               <fieldset>
-                <div className="helpText">{app.translator.trans('askvortsov-pwa.admin.pwa.about.name_text')}</div>
-                <input className="FormControl" bidi={this.setting('askvortsov-pwa.longName')} required={true} />
+                <div className="helpText">
+                  {app.translator.trans(
+                    "askvortsov-pwa.admin.pwa.about.long_name_text"
+                  )}
+                </div>
+                <input
+                  className="FormControl"
+                  bidi={this.values["askvortsov-pwa.longName"]}
+                />
               </fieldset>
               <fieldset>
                 <div className="helpText">{app.translator.trans('askvortsov-pwa.admin.pwa.about.description_text')}</div>

--- a/js/src/admin/components/PWAPage.js
+++ b/js/src/admin/components/PWAPage.js
@@ -93,7 +93,8 @@ export default class PWAPage extends ExtensionPage {
                 </div>
                 <input
                   className="FormControl"
-                  bidi={this.values["askvortsov-pwa.shortName"]}
+                  bidi={this.setting("askvortsov-pwa.shortName")}
+                  placeholder={this.setting("forum_title")()}
                 ></input>
               </fieldset>
               <fieldset>
@@ -104,7 +105,8 @@ export default class PWAPage extends ExtensionPage {
                 </div>
                 <input
                   className="FormControl"
-                  bidi={this.values["askvortsov-pwa.longName"]}
+                  bidi={this.setting("askvortsov-pwa.longName")}
+                  placeholder={this.setting("forum_title")()}
                 />
               </fieldset>
               <fieldset>

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -6,9 +6,9 @@ askvortsov-pwa:
     pwa:
       about:
         description_text: You can set the description on the 'Basics' page in your admin dashboard.
-        name_text: Enter a longer name to be used in your PWA.
+        long_name_text: The name of the web application displayed to the user.
         heading: About
-        short_name_text: You can set the short name on the 'Basics' page in your admin dashboard.
+        short_name_text: The name of the application displayed to the user if there is not enough space for the long name.
       colors:
         heading: Colors
         background_color_text: This is used as a placeholder color for the splash screen that's displayed while your PWA is being loaded. It is not used when the app is actually loaded.

--- a/src/Api/Controller/ShowPWASettingsController.php
+++ b/src/Api/Controller/ShowPWASettingsController.php
@@ -81,7 +81,7 @@ class ShowPWASettingsController extends AbstractShowController
             }
         }
 
-        if (!$this->settings->get('askvortsov-pwa.longName')) {
+        if (!isset($this->buildManifest()['name'])) {
             $status_messages[] = [
                 'type'    => 'error',
                 'message' => $this->translator->trans('askvortsov-pwa.admin.status.no_name'),

--- a/src/PWATrait.php
+++ b/src/PWATrait.php
@@ -25,7 +25,7 @@ trait PWATrait
         $basePath = rtrim(parse_url($this->app->url(), PHP_URL_PATH), '/').'/' ?: '/';
         $manifest = [
             'name'        => $this->settings->get('askvortsov-pwa.longName', $this->settings->get('forum_title')),
-            'short_name'  => $this->settings->get('askvortsov-pwa.shortName', $this->settings->get('forum_title')),
+            'short_name'  => $this->settings->get('askvortsov-pwa.shortName'),
             'description' => $this->settings->get('forum_description', ''),
             //"categories" => $this->settings->get('askvortsov-pwa.categories', []),
             'start_url'        => $basePath,

--- a/src/PWATrait.php
+++ b/src/PWATrait.php
@@ -25,7 +25,7 @@ trait PWATrait
         $basePath = rtrim(parse_url($this->app->url(), PHP_URL_PATH), '/').'/' ?: '/';
         $manifest = [
             'name'        => $this->settings->get('askvortsov-pwa.longName', $this->settings->get('forum_title')),
-            'short_name'  => $this->settings->get('forum_title'),
+            'short_name'  => $this->settings->get('askvortsov-pwa.shortName', $this->settings->get('forum_title')),
             'description' => $this->settings->get('forum_description', ''),
             //"categories" => $this->settings->get('askvortsov-pwa.categories', []),
             'start_url'        => $basePath,

--- a/src/PWATrait.php
+++ b/src/PWATrait.php
@@ -25,7 +25,7 @@ trait PWATrait
         $basePath = rtrim(parse_url($this->app->url(), PHP_URL_PATH), '/').'/' ?: '/';
         $manifest = [
             'name'        => $this->settings->get('askvortsov-pwa.longName', $this->settings->get('forum_title')),
-            'short_name'  => $this->settings->get('askvortsov-pwa.shortName'),
+            'short_name'  => $this->settings->get('askvortsov-pwa.shortName', $this->settings->get('forum_title')),
             'description' => $this->settings->get('forum_description', ''),
             //"categories" => $this->settings->get('askvortsov-pwa.categories', []),
             'start_url'        => $basePath,


### PR DESCRIPTION
1. Default both short and long name to forum's title; simplifying initial configuration.
2. The `apple-mobile-web-app-title` ignored PWA name settings and just set the forum title.
   Apple doesn't honour short_name/name logic, so default to short name (iOS app name space is tiny), fall back to long name, fall back to forum title.

Addresses https://github.com/askvortsov1/flarum-pwa/issues/17

Please test.