### PR TITLE
Fix PHP 8.2 warnings, add PHPStan, refactor type hinting, and fix notification link and content

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,11 +1,12 @@
 name: Progressive Web App PHP
 
-on: [workflow_dispatch, push, pull_request]
+on: [ workflow_dispatch, push, pull_request ]
 
 jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
     with:
       enable_backend_testing: false
+      enable_phpstan: true
 
       backend_directory: .

--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,15 @@
                 "styleci": true
             }
         }
+    },
+    "require-dev": {
+        "flarum/phpstan": "^1.0"
+    },
+    "scripts": {
+        "analyse:phpstan": "phpstan analyse",
+        "clear-cache:phpstan": "phpstan clear-result-cache"
+    },
+    "scripts-descriptions": {
+        "analyse:phpstan": "Run static analysis"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "forum": "https://discuss.flarum.org/d/23219-progressive-web-app-and-push-notifications"
     },
     "require": {
-        "flarum/core": "^1.0.0",
-        "minishlink/web-push": "^6.0"
+        "flarum/core": "^1.7",
+        "minishlink/web-push": "^8.0"
     },
     "suggest": {
         "ext-gmp": "This can improve push notification performance."

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+  - vendor/flarum/phpstan/extension.neon
+
+parameters:
+  # The level will be increased in Flarum 2.0
+  level: 5
+  paths:
+    - src
+    - extend.php
+  excludePaths:
+    - *.blade.php
+  checkMissingIterableValueType: false
+  databaseMigrationsPath: ['migrations']

--- a/src/Api/Controller/AddPushSubscriptionController.php
+++ b/src/Api/Controller/AddPushSubscriptionController.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Flarum\Api\Controller\AbstractCreateController;
 use Flarum\Http\RequestUtil;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Exception\NotAuthenticatedException;
 use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -37,11 +38,8 @@ class AddPushSubscriptionController extends AbstractCreateController
         'user',
     ];
 
-    protected $settings;
+    protected SettingsRepositoryInterface $settings;
 
-    /**
-     * @param SettingsRepositoryInterface $settings
-     */
     public function __construct(SettingsRepositoryInterface $settings)
     {
         $this->settings = $settings;
@@ -49,6 +47,8 @@ class AddPushSubscriptionController extends AbstractCreateController
 
     /**
      * {@inheritdoc}
+     * @throws NotAuthenticatedException
+     * @throws InvalidParameterException|PermissionDeniedException
      */
     protected function data(ServerRequestInterface $request, Document $document)
     {
@@ -104,7 +104,7 @@ class AddPushSubscriptionController extends AbstractCreateController
      *
      * @var string[]
      */
-    public static $push_host_allowlist = [
+    public static array $push_host_allowlist = [
         'android.googleapis.com',
         'fcm.googleapis.com',
         'updates.push.services.mozilla.com',

--- a/src/Api/Controller/DeleteLogoController.php
+++ b/src/Api/Controller/DeleteLogoController.php
@@ -17,6 +17,7 @@ use Flarum\Api\Controller\AbstractDeleteController;
 use Flarum\Http\Exception\RouteNotFoundException;
 use Flarum\Http\RequestUtil;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
@@ -27,19 +28,10 @@ class DeleteLogoController extends AbstractDeleteController
 {
     use PWATrait;
 
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
+    protected SettingsRepositoryInterface $settings;
 
-    /**
-     * @var Filesystem
-     */
-    protected $uploadDir;
+    protected Filesystem $uploadDir;
 
-    /**
-     * @param SettingsRepositoryInterface $settings
-     */
     public function __construct(SettingsRepositoryInterface $settings, Factory $filesystemFactory)
     {
         $this->settings = $settings;
@@ -48,8 +40,9 @@ class DeleteLogoController extends AbstractDeleteController
 
     /**
      * {@inheritdoc}
+     * @throws PermissionDeniedException|RouteNotFoundException
      */
-    protected function delete(ServerRequestInterface $request)
+    protected function delete(ServerRequestInterface $request): EmptyResponse
     {
         RequestUtil::getActor($request)->assertAdmin();
 

--- a/src/Api/Controller/ResetVAPIDKeysController.php
+++ b/src/Api/Controller/ResetVAPIDKeysController.php
@@ -12,8 +12,11 @@
 namespace Askvortsov\FlarumPWA\Api\Controller;
 
 use Askvortsov\FlarumPWA\PushSubscription;
+use ErrorException;
+use Exception;
 use Flarum\Http\RequestUtil;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Exception\PermissionDeniedException;
 use Laminas\Diactoros\Response\JsonResponse;
 use Minishlink\WebPush\VAPID;
 use Psr\Http\Message\ResponseInterface;
@@ -23,14 +26,8 @@ use RuntimeException;
 
 class ResetVAPIDKeysController implements RequestHandlerInterface
 {
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
+    protected SettingsRepositoryInterface $settings;
 
-    /**
-     * @param SettingsRepositoryInterface $settings
-     */
     public function __construct(SettingsRepositoryInterface $settings)
     {
         $this->settings = $settings;
@@ -38,6 +35,8 @@ class ResetVAPIDKeysController implements RequestHandlerInterface
 
     /**
      * {@inheritdoc}
+     * @throws PermissionDeniedException|ErrorException
+     * @throws Exception
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
@@ -49,7 +48,7 @@ class ResetVAPIDKeysController implements RequestHandlerInterface
             $this->settings->set('askvortsov-pwa.vapid.success', false);
             $this->settings->set('askvortsov-pwa.vapid.error', $e->getMessage());
 
-            throw new \Exception($e->getMessage());
+            throw new Exception($e->getMessage());
         }
 
         $this->settings->set('askvortsov-pwa.vapid.success', true);

--- a/src/Api/Controller/UploadLogoController.php
+++ b/src/Api/Controller/UploadLogoController.php
@@ -16,6 +16,7 @@ use Askvortsov\FlarumPWA\Util;
 use Flarum\Api\Controller\UploadImageController;
 use Flarum\Http\Exception\RouteNotFoundException;
 use Flarum\Http\RequestUtil;
+use Flarum\User\Exception\PermissionDeniedException;
 use Illuminate\Support\Arr;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
@@ -27,13 +28,11 @@ class UploadLogoController extends UploadImageController
 {
     use PWATrait;
 
-    /**
-     * @var string
-     */
-    protected $size;
+    protected int $size;
 
     /**
      * {@inheritdoc}
+     * @throws PermissionDeniedException|RouteNotFoundException
      */
     public function data(ServerRequestInterface $request, Document $document)
     {

--- a/src/Api/Serializer/PWASettingsSerializer.php
+++ b/src/Api/Serializer/PWASettingsSerializer.php
@@ -28,16 +28,16 @@ class PWASettingsSerializer extends AbstractSerializer
      *
      * @throws InvalidArgumentException
      */
-    protected function getDefaultAttributes($settings)
+    protected function getDefaultAttributes($settings): array
     {
         return [
-            'manifest'        => $settings['manifest'],
-            'sizes'           => $settings['sizes'],
+            'manifest' => $settings['manifest'],
+            'sizes' => $settings['sizes'],
             'status_messages' => $settings['status_messages'],
         ];
     }
 
-    public function getId($model)
+    public function getId(mixed $model): string
     {
         return 'global';
     }

--- a/src/Api/Serializer/PushSubscriptionSerializer.php
+++ b/src/Api/Serializer/PushSubscriptionSerializer.php
@@ -13,6 +13,7 @@ namespace Askvortsov\FlarumPWA\Api\Serializer;
 
 use Flarum\Api\Serializer\AbstractSerializer;
 use Flarum\Api\Serializer\BasicUserSerializer;
+use Tobscure\JsonApi\Relationship;
 
 class PushSubscriptionSerializer extends AbstractSerializer
 {
@@ -24,21 +25,16 @@ class PushSubscriptionSerializer extends AbstractSerializer
     /**
      * {@inheritdoc}
      */
-    protected function getDefaultAttributes($subscription)
+    protected function getDefaultAttributes($subscription): array
     {
         return [
-            'endpoint'                 => $subscription->endpoint,
-            'vapidPublicKey'           => $subscription->vapid_public_key,
-            'expiresAt'                => $this->formatDate($subscription->expires_at),
+            'endpoint' => $subscription->endpoint,
+            'vapidPublicKey' => $subscription->vapid_public_key,
+            'expiresAt' => $this->formatDate($subscription->expires_at),
         ];
     }
 
-    /**
-     * @param $username_request
-     *
-     * @return \Tobscure\JsonApi\Relationship
-     */
-    protected function user($subscription)
+    protected function user($subscription): Relationship
     {
         return $this->hasOne($subscription, BasicUserSerializer::class);
     }

--- a/src/Forum/Controller/OfflineController.php
+++ b/src/Forum/Controller/OfflineController.php
@@ -24,15 +24,9 @@ class OfflineController implements RequestHandlerInterface
 {
     use PWATrait;
 
-    /**
-     * @var Filesystem
-     */
-    protected $assetDir;
+    protected Filesystem $assetDir;
 
-    /**
-     * @var ViewFactory
-     */
-    protected $viewFactory;
+    protected ViewFactory $viewFactory;
 
     public function __construct(FilesystemFactory $filesystemFactory, ViewFactory $viewFactory)
     {

--- a/src/Forum/Controller/ServiceWorkerController.php
+++ b/src/Forum/Controller/ServiceWorkerController.php
@@ -13,6 +13,7 @@ namespace Askvortsov\FlarumPWA\Forum\Controller;
 
 use Askvortsov\FlarumPWA\PWATrait;
 use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Laminas\Diactoros\Response\TextResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -23,20 +24,18 @@ class ServiceWorkerController implements RequestHandlerInterface
 {
     use PWATrait;
 
-    /**
-     * @var Filesystem
-     */
-    protected $assetDir;
+    protected Filesystem $assetDir;
 
     public function __construct(Factory $filesystemFactory)
     {
         $this->assetDir = $filesystemFactory->disk('flarum-assets');
     }
 
+    /**
+     * @throws FileNotFoundException
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $response = new TextResponse($this->assetDir->get('extensions/askvortsov-pwa/sw.js'), 200, ['content-type' => 'text/javascript; charset=utf-8']);
-
-        return $response;
+        return new TextResponse($this->assetDir->get('extensions/askvortsov-pwa/sw.js'), 200, ['content-type' => 'text/javascript; charset=utf-8']);
     }
 }

--- a/src/Job/SendPushNotificationsJob.php
+++ b/src/Job/SendPushNotificationsJob.php
@@ -12,20 +12,18 @@
 namespace Askvortsov\FlarumPWA\Job;
 
 use Askvortsov\FlarumPWA\PushSender;
+use ErrorException;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Queue\AbstractJob;
 
 class SendPushNotificationsJob extends AbstractJob
 {
-    /**
-     * @var BlueprintInterface
-     */
-    private $blueprint;
+    private BlueprintInterface $blueprint;
 
     /**
      * @var int[]
      */
-    private $recipientIds;
+    private array $recipientIds;
 
     public function __construct(BlueprintInterface $blueprint, array $recipientIds = [])
     {
@@ -33,7 +31,10 @@ class SendPushNotificationsJob extends AbstractJob
         $this->recipientIds = $recipientIds;
     }
 
-    public function handle(PushSender $pushSender)
+    /**
+     * @throws ErrorException
+     */
+    public function handle(PushSender $pushSender): void
     {
         $pushSender->notify($this->blueprint, $this->recipientIds);
     }

--- a/src/PWATrait.php
+++ b/src/PWATrait.php
@@ -21,31 +21,31 @@ trait PWATrait
     /**
      * @return string
      */
-    protected function getBasePath()
+    protected function getBasePath(): string
     {
-        /** @var UrlGenerator */
+        /** @var UrlGenerator $url */
         $url = resolve(UrlGenerator::class);
 
-        return rtrim(parse_url($url->to('forum')->base(), PHP_URL_PATH) ?? '/', '/').'/';
+        return rtrim(parse_url($url->to('forum')->base(), PHP_URL_PATH) ?? '/', '/') . '/';
     }
 
     /**
      * @return array<array{'src': string, 'sizes': string, 'type': string}>
      */
-    protected function getIcons()
+    protected function getIcons(): array
     {
-        /** @var Cloud */
+        /** @var Cloud $assetsFilesystem */
         $assetsFilesystem = resolve(Factory::class)->disk('flarum-assets');
-        /** @var SettingsRepositoryInterface */
+        /** @var SettingsRepositoryInterface $settings */
         $settings = resolve(SettingsRepositoryInterface::class);
 
         $icons = [];
         foreach (Util::$ICON_SIZES as $size) {
             if ($path = $settings->get("askvortsov-pwa.icon_{$size}_path")) {
                 $icons[] = [
-                    'src'   => $assetsFilesystem->url($path),
+                    'src' => $assetsFilesystem->url($path),
                     'sizes' => "{$size}x{$size}",
-                    'type'  => 'image/png',
+                    'type' => 'image/png',
                 ];
             }
         }
@@ -53,22 +53,22 @@ trait PWATrait
         return $icons;
     }
 
-    protected function buildManifest()
+    protected function buildManifest(): array
     {
-        /** @var SettingsRepositoryInterface */
+        /** @var SettingsRepositoryInterface $settings */
         $settings = resolve(SettingsRepositoryInterface::class);
 
         $basePath = $this->getBasePath();
         $manifest = [
-            'name'        => $settings->get('askvortsov-pwa.longName') ?: $settings->get('forum_title'),
+            'name' => $settings->get('askvortsov-pwa.longName') ?: $settings->get('forum_title'),
             'description' => $settings->get('forum_description', ''),
             //"categories" => $settings->get('askvortsov-pwa.categories', []),
-            'start_url'        => $basePath,
-            'scope'            => $basePath,
-            'dir'              => 'auto',
-            'theme_color'      => $settings->get('askvortsov-pwa.themeColor') ?: $settings->get('theme_primary_color'),
-            'display'          => 'standalone',
-            'icons'            => $this->getIcons(),
+            'start_url' => $basePath,
+            'scope' => $basePath,
+            'dir' => 'auto',
+            'theme_color' => $settings->get('askvortsov-pwa.themeColor') ?: $settings->get('theme_primary_color'),
+            'display' => 'standalone',
+            'icons' => $this->getIcons(),
         ];
 
         if ($backgroundColor = $settings->get('askvortsov-pwa.backgroundColor')) {

--- a/src/PWATrait.php
+++ b/src/PWATrait.php
@@ -26,7 +26,7 @@ trait PWATrait
         /** @var UrlGenerator */
         $url = resolve(UrlGenerator::class);
 
-        return rtrim(parse_url($url->to('forum')->base(), PHP_URL_PATH), '/').'/' ?: '/';
+        return rtrim(parse_url($url->to('forum')->base(), PHP_URL_PATH) ?? '/', '/').'/';
     }
 
     /**

--- a/src/PushNotificationDriver.php
+++ b/src/PushNotificationDriver.php
@@ -17,13 +17,11 @@ use Flarum\Notification\Driver\NotificationDriverInterface;
 use Flarum\User\User;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Support\Arr;
+use ReflectionException;
 
 class PushNotificationDriver implements NotificationDriverInterface
 {
-    /**
-     * @var Queue
-     */
-    protected $queue;
+    protected Queue $queue;
 
     public function __construct(Queue $queue)
     {
@@ -32,6 +30,7 @@ class PushNotificationDriver implements NotificationDriverInterface
 
     /**
      * {@inheritDoc}
+     * @throws ReflectionException
      */
     public function registerType(string $blueprintClass, array $enabled): void
     {
@@ -46,10 +45,11 @@ class PushNotificationDriver implements NotificationDriverInterface
 
     /**
      * {@inheritDoc}
+     * @throws ReflectionException
      */
     public function send(BlueprintInterface $blueprint, array $users): void
     {
-        if (! PushSender::canSend(get_class($blueprint))) {
+        if (!PushSender::canSend(get_class($blueprint))) {
             return;
         }
 

--- a/src/PushSender.php
+++ b/src/PushSender.php
@@ -156,12 +156,7 @@ class PushSender
         $link = $this->url->to('forum')->base();
 
         $subject = $blueprint->getSubject();
-        $subjectModel = $blueprint->getSubjectModel();
-
-        if (in_array($blueprint->getType(), ['newPost', 'byobuPrivateDiscussionReplied'])) {
-            $subject = $blueprint->post;
-            $subjectModel = CommentPost::class;
-        }
+        $subjectModel = $blueprint::getSubjectModel();
 
         switch ($subjectModel) {
             case User::class:

--- a/src/PushSender.php
+++ b/src/PushSender.php
@@ -12,6 +12,8 @@
 namespace Askvortsov\FlarumPWA;
 
 use Carbon\Carbon;
+use ErrorException;
+use Exception;
 use Flarum\Discussion\Discussion;
 use Flarum\Http\UrlGenerator;
 use Flarum\Notification\Blueprint\BlueprintInterface;
@@ -20,44 +22,38 @@ use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
+use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Minishlink\WebPush\MessageSentReport;
 use Minishlink\WebPush\Subscription;
 use Minishlink\WebPush\WebPush;
 use Psr\Log\LoggerInterface;
+use ReflectionException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PushSender
 {
     use PWATrait;
 
-    /**
-     * @var Cloud
-     */
-    protected $assetsFilesystem;
+    protected Cloud|Filesystem $assetsFilesystem;
 
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    protected LoggerInterface $logger;
 
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
+    protected SettingsRepositoryInterface $settings;
 
-    /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
+    protected TranslatorInterface $translator;
 
-    /**
-     * @var UrlGenerator
-     */
-    protected $url;
+    protected UrlGenerator $url;
 
-    public function __construct(Factory $filesystemFactory, LoggerInterface $logger, SettingsRepositoryInterface $settings, TranslatorInterface $translator, UrlGenerator $url)
-    {
+    public function __construct(
+        Factory $filesystemFactory,
+        LoggerInterface $logger,
+        SettingsRepositoryInterface $settings,
+        TranslatorInterface $translator,
+        UrlGenerator $url
+    ) {
         $this->assetsFilesystem = $filesystemFactory->disk('flarum-assets');
         $this->logger = $logger;
         $this->settings = $settings;
@@ -65,12 +61,20 @@ class PushSender
         $this->url = $url;
     }
 
-    public static function canSend(string $blueprintClass)
+    /**
+     * @throws ReflectionException
+     */
+    public static function canSend(string $blueprintClass): bool
     {
-        return (new \ReflectionClass($blueprintClass))->implementsInterface(MailableInterface::class) || in_array($blueprintClass, static::$SUPPORTED_NON_EMAIL_BLUEPRINTS);
+        return (new \ReflectionClass($blueprintClass))->implementsInterface(MailableInterface::class) || in_array($blueprintClass,
+                static::$SUPPORTED_NON_EMAIL_BLUEPRINTS);
     }
 
-    public function notify(BlueprintInterface $blueprint, array $userIds = [])
+    /**
+     * @throws ErrorException
+     * @throws Exception
+     */
+    public function notify(BlueprintInterface $blueprint, array $userIds = []): void
     {
         $users = User::whereIn('id', $userIds)->get()->all();
 
@@ -89,8 +93,8 @@ class PushSender
             foreach ($subscriptions as $subscription) {
                 $notifications[] = [
                     'subscription' => Subscription::create([
-                        'endpoint'        => $subscription->endpoint,
-                        'keys'            => json_decode($subscription->keys, true),
+                        'endpoint' => $subscription->endpoint,
+                        'keys' => json_decode($subscription->keys, true),
                     ]),
                     'payload' => $payload,
                 ];
@@ -99,8 +103,8 @@ class PushSender
 
         $auth = [
             'VAPID' => [
-                'subject'    => $this->url->to('forum')->base(),
-                'publicKey'  => Util::url_encode($this->settings->get('askvortsov-pwa.vapid.public')),
+                'subject' => $this->url->to('forum')->base(),
+                'publicKey' => Util::url_encode($this->settings->get('askvortsov-pwa.vapid.public')),
                 'privateKey' => Util::url_encode($this->settings->get('askvortsov-pwa.vapid.private')),
             ],
         ];
@@ -146,7 +150,7 @@ class PushSender
         $this->log("[PWA PUSH] Sent $sentCounter notifications successfully.\n\n");
     }
 
-    protected function getPayload(BlueprintInterface $blueprint)
+    protected function getPayload(BlueprintInterface $blueprint): array
     {
         $content = '';
         $link = $this->url->to('forum')->base();
@@ -161,7 +165,7 @@ class PushSender
 
         switch ($subjectModel) {
             case User::class:
-                $link = $this->url->to('forum')->route('user', ['username' =>  $subject->display_name]);
+                $link = $this->url->to('forum')->route('user', ['username' => $subject->display_name]);
                 break;
             case Discussion::class:
                 $content = $this->getRelevantPostContent($subject);
@@ -169,14 +173,15 @@ class PushSender
                 break;
             case Post::class:
                 $content = $subject->type === 'comment' ? $subject->formatContent() : '';
-                $link = $this->url->to('forum')->route('discussion', ['id' => $subject->discussion_id, 'near' => $subject->number]);
+                $link = $this->url->to('forum')->route('discussion',
+                    ['id' => $subject->discussion_id, 'near' => $subject->number]);
                 break;
         }
 
         $payload = [
-            'title'   => $this->excerpt($this->getTitle($blueprint), 30),
+            'title' => $this->excerpt($this->getTitle($blueprint), 30),
             'content' => $this->excerpt($content),
-            'link'    => $link,
+            'link' => $link,
         ];
 
         if ($faviconPath = $this->settings->get('favicon_path')) {
@@ -194,7 +199,7 @@ class PushSender
         return $payload;
     }
 
-    protected function excerpt($str, $maxLen = 200)
+    protected function excerpt(string $str, int $maxLen = 200): string
     {
         $str = strip_tags($str);
         if (mb_strlen($str) > $maxLen) {
@@ -205,7 +210,7 @@ class PushSender
         return $str;
     }
 
-    protected function getRelevantPostContent($discussion)
+    protected function getRelevantPostContent($discussion): string
     {
         $relevantPost = $discussion->mostRelevantPost ?: $discussion->firstPost ?: $discussion->comments->first();
 
@@ -216,31 +221,30 @@ class PushSender
         return $relevantPost->formatContent();
     }
 
-    protected function getTitle($blueprint)
+    protected function getTitle(BlueprintInterface $blueprint): string
     {
         if (is_subclass_of($blueprint, MailableInterface::class)) {
             return $blueprint->getEmailSubject($this->translator);
         } elseif (in_array(get_class($blueprint), static::$SUPPORTED_NON_EMAIL_BLUEPRINTS)) {
-            switch ($blueprint->getType()) {
-                case 'postLiked':
-                    return $this->translator->trans(
-                        'flarum-likes.forum.notifications.post_liked_text',
-                        ['username' => $blueprint->getFromUser()->getDisplayNameAttribute()]
-                    );
+            if ($blueprint->getType() == 'postLiked') {
+                return $this->translator->trans(
+                    'flarum-likes.forum.notifications.post_liked_text',
+                    ['username' => $blueprint->getFromUser()->getDisplayNameAttribute()]
+                );
             }
         }
 
         return '';
     }
 
-    protected function log($message)
+    protected function log(string $message): void
     {
         if ($this->settings->get('askvortsov-pwa.debug', false)) {
             $this->logger->info($message);
         }
     }
 
-    public static $SUPPORTED_NON_EMAIL_BLUEPRINTS = [
+    public static array $SUPPORTED_NON_EMAIL_BLUEPRINTS = [
         "Flarum\Likes\Notification\PostLikedBlueprint",
         "Flarum\Notification\DiscussionRenamedBlueprint",
     ];

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -14,6 +14,7 @@ namespace Askvortsov\FlarumPWA;
 use Flarum\Database\AbstractModel;
 use Flarum\Database\ScopeVisibilityTrait;
 use Flarum\User\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PushSubscription extends AbstractModel
 {
@@ -26,10 +27,7 @@ class PushSubscription extends AbstractModel
      */
     protected $dates = ['expires_at'];
 
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }

--- a/src/Util.php
+++ b/src/Util.php
@@ -17,6 +17,10 @@ class Util
 
     public static function url_encode($data)
     {
+        if (empty($data)) {
+            return '';
+        }
+
         return rtrim(strtr($data, ['+' => '-', '/' => '_']), '=');
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -13,9 +13,9 @@ namespace Askvortsov\FlarumPWA;
 
 class Util
 {
-    public static $ICON_SIZES = [48, 72, 96, 144, 196, 256, 512];
+    public static array $ICON_SIZES = [48, 72, 96, 144, 196, 256, 512];
 
-    public static function url_encode($data)
+    public static function url_encode($data): string
     {
         if (empty($data)) {
             return '';


### PR DESCRIPTION
- Fixed PHP 8.2 warnings by properly handling null parameters.
- Updated minishlink/web-push to the latest version. PHP 8.0 is now minimum supported version.
- Added PHPStan to the project, which will help us find issues more efficiently.
- Refactored the code to use native PHP variable types to make it easier to catch issues.
- **Fixed the discussion link and content.**

Specifically, I found that the following conditional block was causing problems:
```php
if (in_array($blueprint->getType(), ['newPost', 'byobuPrivateDiscussionReplied'])) {
    $subject = $blueprint->post;
    $subjectModel = CommentPost::class;
}
```
This block was modifying the $subject and $subjectModel variables unnecessarily. The correct implementation was already present before this block:
```php
$subject = $blueprint->getSubject();
$subjectModel = $blueprint->getSubjectModel();
```
So, I've removed the problematic conditional block entirely, which resolved the issue.
I have tested the push notifications with new posts and with `fof/byobu`. Everything is working as expected, with no errors or issues found.