### PR TITLE
Add plugin for imdong/visible-to-op-only compatibility

### DIFF
--- a/src/PushSender.php
+++ b/src/PushSender.php
@@ -94,7 +94,7 @@ class PushSender
 
         foreach ($users as $user) {
             // check permissions
-            if ($opOnlyIsEnable && !$user->can('canViewPosts', $blueprint)) {
+            if ($opOnlyIsEnable && ! $user->can('canViewPosts', $blueprint)) {
                 continue;
             }
 

--- a/src/PushSender.php
+++ b/src/PushSender.php
@@ -89,7 +89,15 @@ class PushSender
 
         $sendingCounter = 0;
 
+        // ext visible-to-op-only
+        $opOnlyIsEnable = resolve('flarum.extensions')->isEnabled('imdong-visible-to-op-only');
+
         foreach ($users as $user) {
+            // check permissions
+            if ($opOnlyIsEnable && !$user->can('canViewPosts', $blueprint)) {
+                continue;
+            }
+
             $subscriptions = $user->pushSubscriptions;
             $sendingCounter += $subscriptions->count();
             foreach ($subscriptions as $subscription) {


### PR DESCRIPTION
Add Creating push, if the visible-to-op-only is turned on, it will not be pushed to users who do not have permission to view.

Remarks：

Hello, I am the developer of the plug-in imdong/visible-to-op-only. My plug-in has a function to increase the user's invisible area for some tags. However, if the user pays attention to this post or tag without viewing permission, it is possible to see some hidden information in the push.

In this regard, I hope to add some judgment compatible codes to your plug-in. I know that such strong coupling may not be a good solution, but I do not seem to find a better solution. If you have a better solution or are willing to open some api, I am very happy to adapt the api you provide on my plug-in.

Anyway, thank you first.