### PR TITLE
Downgrade Firebase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "flarum/core": "^1.7",
         "minishlink/web-push": "^7.0",
         "spomky-labs/base64url" : "^2.0",
-        "kreait/firebase-php": "^7.9"
+        "kreait/firebase-php": "^5.0"
     },
     "suggest": {
         "ext-gmp": "This can improve push notification performance."

--- a/js/src/admin/components/PWAPage.js
+++ b/js/src/admin/components/PWAPage.js
@@ -172,8 +172,13 @@ export default class PWAPage extends ExtensionPage {
                   setting: 'askvortsov-pwa.windowControlsOverlay',
                   label: app.translator.trans('askvortsov-pwa.admin.pwa.other.window_controls_overlay_label'),
                   help: app.translator.trans('askvortsov-pwa.admin.pwa.other.window_controls_overlay_text', {
-                    compatibilitylink: <a href="https://caniuse.com/mdn-api_windowcontrolsoverlay" tabindex="-1"/>,
-                    learnlink: <a href="https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay" tabindex="-1"/>
+                    compatibilitylink: <a href="https://caniuse.com/mdn-api_windowcontrolsoverlay" tabindex="-1" />,
+                    learnlink: (
+                      <a
+                        href="https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay"
+                        tabindex="-1"
+                      />
+                    ),
                   }),
                   type: 'bool',
                 })}

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -15,6 +15,8 @@ use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Container\Container;
 use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Exception\Messaging\AuthenticationError;
+use Kreait\Firebase\Exception\Messaging\NotFound;
 use Kreait\Firebase\Messaging\CloudMessage;
 use Kreait\Firebase\Messaging\Notification;
 use Psr\Log\LoggerInterface;
@@ -59,6 +61,10 @@ class FirebasePushSender
             $this->logger->error('Firebase config invalid');
 
             return;
+        } catch (AuthenticationError) {
+            $this->logger->error('Auth error from APNS or Web Push Service');
+        } catch (NotFound) {
+            // Remove the device from the database
         }
 
         FirebasePushSubscription::whereIn('user_id', $userIds)->each(function (FirebasePushSubscription $subscription) use ($messaging, $blueprint) {

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -84,8 +84,18 @@ class FirebasePushSender
 
     private function hasValidFirebaseSettings(): bool
     {
+        $config = $this->settings->get('askvortsov-pwa.firebaseConfig');
+
+        $this->logger->info('----- FIREBASE CONFIG ------');
+        $this->logger->info($config);
+        $this->logger->info('----- FIREBASE CONFIG ------');
+
+        if (! $config) {
+            return false;
+        }
+
         try {
-            return (bool) json_encode($this->settings->get('askvortsov-pwa.firebaseConfig'));
+            return (bool) json_encode($config);
         } catch (\Throwable) {
             return false;
         }

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -71,7 +71,8 @@ class FirebasePushSender
             } catch (AuthenticationError) {
                 $this->logger->error('Auth error from APNS or Web Push Service');
             } catch (NotFound) {
-                // Remove the device from the database
+                $this->logger->info("Removing expired token {$subscription->token}...");
+                $subscription->delete();
             }
         });
     }

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -86,10 +86,6 @@ class FirebasePushSender
     {
         $config = $this->settings->get('askvortsov-pwa.firebaseConfig');
 
-        $this->logger->info('----- FIREBASE CONFIG ------');
-        $this->logger->info($config);
-        $this->logger->info('----- FIREBASE CONFIG ------');
-
         if (! $config) {
             return false;
         }

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -65,13 +65,12 @@ class FirebasePushSender
 
         FirebasePushSubscription::whereIn('user_id', $userIds)->each(function (FirebasePushSubscription $subscription) use ($messaging, $blueprint) {
             try {
-                $messaging->send(
-                    $this->newFirebaseCloudMessage($subscription, $blueprint)
-                );
-            } catch (AuthenticationError) {
-                $this->logger->error('Auth error from APNS or Web Push Service');
+                $messaging->send($this->newFirebaseCloudMessage($subscription, $blueprint));
+            } catch (AuthenticationError $e) {
+                $this->logger->error($e->getMessage());
             } catch (NotFound) {
                 $this->logger->info("Removing expired token {$subscription->token}...");
+
                 $subscription->delete();
             }
         });

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -12,6 +12,7 @@
 namespace Askvortsov\FlarumPWA;
 
 use Flarum\Notification\Blueprint\BlueprintInterface;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Container\Container;
 use Kreait\Firebase\Contract\Messaging;
 use Kreait\Firebase\Messaging\CloudMessage;
@@ -26,23 +27,33 @@ class FirebasePushSender
 
     protected LoggerInterface $logger;
 
+    protected SettingsRepositoryInterface $settings;
+
     public function __construct(
         Container $container,
         NotificationBuilder $notifications,
         LoggerInterface $logger,
+        SettingsRepositoryInterface $settings,
     ) {
         $this->container = $container;
         $this->notifications = $notifications;
         $this->logger = $logger;
+        $this->settings = $settings;
     }
 
     public function notify(BlueprintInterface $blueprint, array $userIds = []): void
     {
+        if (! $this->hasValidFirebaseSettings()) {
+            return;
+        }
+
         try {
             // We're using the container to resolve the FirebaseMessagingContract here so we have more
             // control on when and where to log the error. Having it passed on the constructor will mean
             // we'll have to throw an exception and log the error for the user in the exception handler
             // rather than directly in the class that consumes the contract.
+
+            /** @throws FirebaseConfigInvalid */
             $messaging = $this->container->make(Messaging::class);
         } catch (FirebaseConfigInvalid) {
             $this->logger->error('Firebase config invalid');
@@ -69,5 +80,14 @@ class FirebasePushSender
                     'body' => strip_tags($message->body()),
                 ])
             );
+    }
+
+    private function hasValidFirebaseSettings(): bool
+    {
+        try {
+            return (bool) json_encode($this->settings->get('askvortsov-pwa.firebaseConfig'));
+        } catch (\Throwable) {
+            return false;
+        }
     }
 }

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -69,8 +69,6 @@ class FirebasePushSender
             } catch (AuthenticationError $e) {
                 $this->logger->error($e->getMessage());
             } catch (NotFound) {
-                $this->logger->info("Removing expired token {$subscription->token}...");
-
                 $subscription->delete();
             }
         });

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -96,10 +96,8 @@ class FirebasePushSender
             return false;
         }
 
-        try {
-            return (bool) json_encode($config);
-        } catch (\Throwable) {
-            return false;
-        }
+        json_decode($config);
+
+        return json_last_error() === JSON_ERROR_NONE;
     }
 }

--- a/src/FirebasePushSender.php
+++ b/src/FirebasePushSender.php
@@ -61,16 +61,18 @@ class FirebasePushSender
             $this->logger->error('Firebase config invalid');
 
             return;
-        } catch (AuthenticationError) {
-            $this->logger->error('Auth error from APNS or Web Push Service');
-        } catch (NotFound) {
-            // Remove the device from the database
         }
 
         FirebasePushSubscription::whereIn('user_id', $userIds)->each(function (FirebasePushSubscription $subscription) use ($messaging, $blueprint) {
-            $messaging->send(
-                $this->newFirebaseCloudMessage($subscription, $blueprint)
-            );
+            try {
+                $messaging->send(
+                    $this->newFirebaseCloudMessage($subscription, $blueprint)
+                );
+            } catch (AuthenticationError) {
+                $this->logger->error('Auth error from APNS or Web Push Service');
+            } catch (NotFound) {
+                // Remove the device from the database
+            }
         });
     }
 

--- a/src/Job/SendPushNotificationsJob.php
+++ b/src/Job/SendPushNotificationsJob.php
@@ -37,22 +37,10 @@ class SendPushNotificationsJob extends AbstractJob
     /**
      * @throws ErrorException
      */
-    public function handle(PushSender $native, FirebasePushSender $firebase, SettingsRepositoryInterface $settings): void
+    public function handle(PushSender $native, FirebasePushSender $firebase): void
     {
         $native->notify($this->blueprint, $this->recipientIds);
 
-        try {
-            $firebase->notify($this->blueprint, $this->recipientIds);
-        } catch (FirebaseConfigInvalid) {
-        }
-    }
-
-    private function hasValidFirebaseSettings(SettingsRepositoryInterface $settings): bool
-    {
-        try {
-            return (bool) json_encode($settings->get('askvortsov-pwa.firebaseConfig'));
-        } catch (\Throwable) {
-            return false;
-        }
+        $firebase->notify($this->blueprint, $this->recipientIds);
     }
 }

--- a/src/Job/SendPushNotificationsJob.php
+++ b/src/Job/SendPushNotificationsJob.php
@@ -11,13 +11,11 @@
 
 namespace Askvortsov\FlarumPWA\Job;
 
-use Askvortsov\FlarumPWA\FirebaseConfigInvalid;
 use Askvortsov\FlarumPWA\FirebasePushSender;
 use Askvortsov\FlarumPWA\PushSender;
 use ErrorException;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Queue\AbstractJob;
-use Flarum\Settings\SettingsRepositoryInterface;
 
 class SendPushNotificationsJob extends AbstractJob
 {


### PR DESCRIPTION
This PR fixes a couple of things:
- Don't execute any Firebase code at all when the Firebase config is non-existent or invalid.
- "Invalid Firebase config" showing up in the error logs.
- Use a lower version of the Firebase package to support older versions of PHP.
- Remove expired tokens when Firebase fails to send them out.
- Add better logging when the APNs is invalid.