### PR TITLE
Add compatibility to Microsoft Edge

### DIFF
--- a/migrations/2024_06_24_000000_add_length_to_endpoint_str.php
+++ b/migrations/2024_06_24_000000_add_length_to_endpoint_str.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of askvortsov/flarum-pwa
+ *
+ *  Copyright (c) 2021 Alexander Skvortsov.
+ *
+ *  For detailed copyright and license information, please view the
+ *  LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $schema->table('push_subscriptions', function (Blueprint $table) {
+            $table->string('endpoint',1024)->change();
+        });
+    },
+    'down' => function (Builder $schema) {
+    },
+];


### PR DESCRIPTION
Default string field with length 255 is too short for Microsoft Edge, which uses endpoint url up to 500 characters long.
Change length of field endpoint in table push_subscriptions to 1024.