### PR TITLE
fix(post-seq): include post number for New Post notifications, show new post content

### DIFF
--- a/src/NotificationBuilder.php
+++ b/src/NotificationBuilder.php
@@ -79,6 +79,10 @@ class NotificationBuilder
 
         switch ($blueprint::getSubjectModel()) {
             case Discussion::class:
+                if ($blueprint->getType() === 'newPost') {
+                    $content = $blueprint->post->formatContent();
+                    break;
+                }
                 /** @var Discussion $subject */
                 $content = $this->getRelevantPostContent($subject);
                 break;

--- a/src/NotificationBuilder.php
+++ b/src/NotificationBuilder.php
@@ -110,6 +110,8 @@ class NotificationBuilder
 
         $subject = $blueprint->getSubject();
 
+        $data = $blueprint->getData();
+
         switch ($blueprint::getSubjectModel()) {
             case User::class:
                 /** @var User $subject */
@@ -117,10 +119,18 @@ class NotificationBuilder
 
             case Discussion::class:
                 /** @var Discussion $subject */
-                return $this->url->to('forum')->route('discussion', ['id' => $subject->id]);
+
+                $params = ['id' => $subject->id];
+
+                if ( array_key_exists('postNumber', $data)) {
+                    $params['near'] = $data['postNumber'];
+                }
+
+                return $this->url->to('forum')->route('discussion', $params);
 
             case Post::class:
                 /** @var Post $subject */
+
                 return $this->url->to('forum')->route(
                     'discussion',
                     ['id' => $subject->discussion_id, 'near' => $subject->number]

--- a/src/NotificationBuilder.php
+++ b/src/NotificationBuilder.php
@@ -119,10 +119,9 @@ class NotificationBuilder
 
             case Discussion::class:
                 /** @var Discussion $subject */
-
                 $params = ['id' => $subject->id];
 
-                if ( array_key_exists('postNumber', $data)) {
+                if (array_key_exists('postNumber', $data)) {
                     $params['near'] = $data['postNumber'];
                 }
 
@@ -130,7 +129,6 @@ class NotificationBuilder
 
             case Post::class:
                 /** @var Post $subject */
-
                 return $this->url->to('forum')->route(
                     'discussion',
                     ['id' => $subject->discussion_id, 'near' => $subject->number]


### PR DESCRIPTION

# Post URLs for notifications

`[New Post]` notifications are typed as `Discussion` objects, rather than `Post` objects.

As a result, push notifications only link to the discussion URL, rather than the discussion + post number URL, i.e.

`https://example.com/d/foo-discussion`

instead of

`https://example.com/d/foo-discussion/3`

This fix use the postNumber as part of the URL building, if it is available.

This fix also works for fof/byobu new private message notifications

# Post content for discussion posts

Previously, push notifications were always showing the first post in the discussion in their content previews. This fix changes that so that the displayed content is the new post. I'm not very well across the Flarum codebase, and I don't fully understand how `$discussion->mostRelevantPost` is supposed to work, but on my forum it does not appear to work properly in this context.