### PR TITLE
Add support for Badging API

### DIFF
--- a/assets/sw.js
+++ b/assets/sw.js
@@ -31,6 +31,13 @@ const forumPayload = {};
 // Replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline";
 const offlineFallbackPage = "offline";
 
+// Tell Clients that a new Push comes.
+async function alarmPushToClients() {
+  (await clients.matchAll()).forEach(function (client) {
+    client.postMessage(true);
+  });
+}
+
 // Install stage sets up the offline page in the cache and opens a new cache
 self.addEventListener("install", function (event) {
   console.log("[PWA] Install event processing...");
@@ -113,6 +120,10 @@ self.addEventListener('push', function (event) {
     };
 
     const promiseChain = self.registration.showNotification(event.data.json().title, options);
+
+    if (navigator.setAppBadge) navigator.setAppBadge(event.data.json()['app_badge']);
+
+    alarmPushToClients();
 
     event.waitUntil(promiseChain);
   } else {

--- a/js/src/forum/addPushNotifications.js
+++ b/js/src/forum/addPushNotifications.js
@@ -55,6 +55,16 @@ export const refreshSubscription = async (sw) => {
   app.cache.pwaRefreshed = true;
 };
 
+export const dealWithNewPush = () => {
+  navigator.serviceWorker.addEventListener('message', () => {
+    // There's no need to show badge when user is visiting the forum.
+    if (navigator.clearAppBadge) navigator.clearAppBadge();
+
+    // Could we refresh the number of new notifications on the top bar?
+    app.store.find('').then(m.redraw);
+  });
+}
+
 const pushConfigured = () => {
   return app.forum.attribute('vapidPublicKey');
 };
@@ -215,4 +225,6 @@ export default () => {
   extend(SettingsPage.prototype, 'onremove', function () {
     removeFirebasePushNotificationListeners();
   });
+
+  if (navigator.clearAppBadge) navigator.clearAppBadge();
 };

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -5,7 +5,7 @@ import Page from 'flarum/common/components/Page';
 import LinkButton from 'flarum/common/components/LinkButton';
 import SessionDropdown from 'flarum/forum/components/SessionDropdown';
 import addShareButtons from './addShareButtons';
-import addPushNotifications, { refreshSubscription } from './addPushNotifications';
+import addPushNotifications, { refreshSubscription, dealWithNewPush } from './addPushNotifications';
 
 app.initializers.add('askvortsov/flarum-pwa', () => {
   const isInStandaloneMode = () =>
@@ -31,6 +31,7 @@ app.initializers.add('askvortsov/flarum-pwa', () => {
             navigator.serviceWorker.ready.then(() => {
               app.sw = sw;
               refreshSubscription(sw);
+              dealWithNewPush();
             });
           });
       }

--- a/src/PushSender.php
+++ b/src/PushSender.php
@@ -68,13 +68,16 @@ class PushSender
 
         $notifications = [];
 
-        $payload = json_encode($this->getPayload($blueprint));
+        // $payload = json_encode($this->getPayload($blueprint));
+        $basePayload = $this->getPayload($blueprint);
 
         $sendingCounter = 0;
 
         foreach ($users as $user) {
             $subscriptions = $user->pushSubscriptions;
             $sendingCounter += $subscriptions->count();
+            $payload = clone $basePayload;
+            $payload['app_badge'] = $user->getNewNotificationCount();
             foreach ($subscriptions as $subscription) {
                 $notifications[] = [
                     'subscription' => Subscription::create([


### PR DESCRIPTION
I noticed the previous PR was messy, so I've closed that. Features will be pull separately.

This PR aims to add support for Badging API. What changed:

1. Get new notifications count and add it into the payload.
2. Set up the badge in Service Worker and set its value to the count.
3. Message the client (if exists) to do more, such as cancel badging and update the count on the bell.

Note: Not tested yet.